### PR TITLE
feat(fetch): configurable HTTP client timeout

### DIFF
--- a/fetch/fetcher.go
+++ b/fetch/fetcher.go
@@ -75,6 +75,7 @@ type Fetch struct {
 	ResponseMap       *sync.Map
 	InputBody         io.ReadCloser
 	Transport         http.RoundTripper
+	Timeout           time.Duration
 }
 
 func NewFetcher(opt ...Option) *Fetch {
@@ -84,6 +85,7 @@ func NewFetcher(opt ...Option) *Fetch {
 		Transport:         defaultTransport,
 		AddrLocal:         AddrLocal,
 		ResponseMap:       &sync.Map{},
+		Timeout:           20 * time.Second,
 	}
 
 	for _, o := range opt {
@@ -306,7 +308,7 @@ func (f *Fetch) fetchRemote(r *internal.Request) (*internal.Response, error) {
 			redirected = true
 			return nil
 		},
-		Timeout: 20 * time.Second,
+		Timeout: f.Timeout,
 	}
 
 	res, err := client.Do(req)

--- a/fetch/options.go
+++ b/fetch/options.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 )
 
 type UserAgentProvider interface {
@@ -82,5 +83,11 @@ func WithResponseMap(resMap *sync.Map) Option {
 func WithTransport(transport http.RoundTripper) Option {
 	return optionFunc(func(ft *Fetch) {
 		ft.Transport = transport
+	})
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return optionFunc(func(ft *Fetch) {
+		ft.Timeout = timeout
 	})
 }


### PR DESCRIPTION
## Summary
- Add `Timeout` field to `Fetch` struct and `WithTimeout` option
- Default remains 20s for backward compat
- Needed by twintag-go epsilon to raise timeout for AI agent calls